### PR TITLE
fix: JVM OOM issues during gradle build

### DIFF
--- a/build-extras.gradle
+++ b/build-extras.gradle
@@ -1,4 +1,9 @@
-// This file 
+// This file
 // * is referred to in an `apply from` command in `build.gradle`
 // * can be used to customise `build.gradle`
 // * is generated once and not overwritten in SDK generation updates
+
+tasks.withType(JavaCompile).configureEach {
+    options.fork = true
+    options.forkOptions.jvmArgs = ['-Xmx2g', '-XX:MaxMetaspaceSize=1g']
+}


### PR DESCRIPTION
## Description:
The Gradle build [fails with JVM Out-Of-Memory errors](https://github.com/StackOneHQ/stackone-client-java/actions/runs/17468044607/job/49608878278#step:5:1107) when generating async features, because additional classes are created during this process. The default max memory (500 MB) is insufficient for compilation, causing builds to fall back to older Speakeasy versions and skipping async feature generation.

This PR updates the JVM memory settings to more generous values, ensuring:

Async features are generated reliably.

Gradle builds no longer fail due to heap/metaspace limitations.

### Changes:

Increase Gradle JVM max heap and metaspace (via gradle.properties or forked JavaCompile tasks).

### Impact:

No functional changes, only build configuration.

Async code generation now works consistently.